### PR TITLE
Add slash on ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.5.3-slim
-ADD Gemfile* .
+ADD Gemfile* ./
 RUN bundle install --no-cache
-ADD config.ru .
+ADD config.ru ./
 EXPOSE 9292
 CMD ["bundle", "exec", "rackup", "-p", "9292", "-o", "0.0.0.0"]


### PR DESCRIPTION
## WHY

Failed automated build on quay.io:

```
A build step failed: When using ADD with more than one source file, the destination must be a directory and end with a /
```

## WHAT

Added `/` to `ADD` section.